### PR TITLE
Fix: Add max-width and padding to main layout for consistent responsive design

### DIFF
--- a/src/components/layout/Layout.js
+++ b/src/components/layout/Layout.js
@@ -6,7 +6,7 @@ const Layout = ({ children }) => {
   return (
     <section>
       <Header />
-      <main>{children}</main>
+      <main className="max-w-[1190px] px-8 mx-auto box-border">{children}</main>
       <Footer />
     </section>
   );


### PR DESCRIPTION
## Description  
This PR addresses the issue of ensuring a consistent and responsive layout by applying a maximum width of 1190px with 32px padding on both sides to the main layout container. The changes were implemented in the `Layout` component and applied globally to pages where the `Layout` is used. 

## Related Issue  
Fixes #85  

## Type of Change  
- [x] Bug fix  
- [ ] New feature  
- [ ] Refactor  
- [ ] Documentation or Content update  
- [x] UI update  

## Checklist  
- [x] I have tested my changes locally  
- [ ] I have updated documentation (if applicable)  
- [ ] I have added tests (if applicable)  
- [x] I have included screenshots or relevant links (if applicable)  
- [x] My changes follow the project's code style and contribution guidelines    

## Screenshots  

### Before (Without Layout Fix)
<img width="1403" alt="Screenshot 2025-05-06 at 5 01 36 PM" src="https://github.com/user-attachments/assets/4354356a-087a-48be-b5c3-240970d2e8e4" />

<img width="1389" alt="Screenshot 2025-05-06 at 5 02 44 PM" src="https://github.com/user-attachments/assets/809e26db-b870-4ced-8988-38ac27e488f1" />


### After (With Layout Fix)

<img width="1440" alt="Screenshot 2025-05-06 at 4 52 05 PM" src="https://github.com/user-attachments/assets/d277cdec-9095-4ca5-a3b4-b1c70eb881e6" />

<img width="1401" alt="Screenshot 2025-05-06 at 4 54 03 PM" src="https://github.com/user-attachments/assets/44f1fd6b-d01c-482e-bfc2-347a5099ef8e" />

### Notes
Screenshots demonstrate the correct application of `max-width` and padding, ensuring a responsive and centered layout across pages.

