### PR TITLE
Add Slack Link to "Join Our Community" Button #126

### DIFF
--- a/src/modules/component/OurCommunity.jsx
+++ b/src/modules/component/OurCommunity.jsx
@@ -1,19 +1,41 @@
-import React from 'react'
-import Button from '../../components/Button'
+import React from "react";
+import Button from "../../components/Button";
 
 const OurCommunity = () => {
   return (
-    <section className='flex items-center gap-x-[30px] py-20 pl-24'>
-<aside className='w-1/2'>
-    <h2 className="text-black text-[64px] leading-[92.8px] font-semibold">Our Community</h2>
-    <p className="text-[#04354A] -tracking-[1px] text-2xl">Join our vibrant community of open source enthusiasts. Connect with fellow developers, designers, and technical writers. Share knowledge, collaborate on projects, and grow together in the open source ecosystem.</p>
-    <div className='mt-11'>
-        <Button text="Join Our Community" className="bg-blue text-white text-base font-semibold px-[114px] py-4"/>
-    </div>
-</aside>
-<aside className='w-1/2  relative right-0'><img src="/images/community-image.svg" className='h-[30rem] w-full' alt="Lot of people sanding together" /></aside>
+    <section className="flex items-center gap-x-[30px] py-20 pl-24">
+      <aside className="w-1/2">
+        <h2 className="text-black text-[64px] leading-[92.8px] font-semibold">
+          Our Community
+        </h2>
+        <p className="text-[#04354A] -tracking-[1px] text-2xl">
+          Join our vibrant community of open source enthusiasts. Connect with
+          fellow developers, designers, and technical writers. Share knowledge,
+          collaborate on projects, and grow together in the open source
+          ecosystem.
+        </p>
+        <div className="mt-11">
+          <a
+            href="https://opennestafrica.slack.com/join/shared_invite/zt-34axoub3n-lQTtFlPezkyls8~ncwHfiQ#/shared-invite/email"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Button
+              text="Join Our Community"
+              className="bg-blue text-white text-base font-semibold px-[114px] py-4"
+            />
+          </a>
+        </div>
+      </aside>
+      <aside className="w-1/2  relative right-0">
+        <img
+          src="/images/community-image.svg"
+          className="h-[30rem] w-full"
+          alt="Lot of people sanding together"
+        />
+      </aside>
     </section>
-  )
-}
+  );
+};
 
-export default OurCommunity
+export default OurCommunity;


### PR DESCRIPTION
## Description  
Description
This PR resolves [Issue #54](https://github.com/open-nest-africa/website/issues/54) by updating the "Join Our Community" button to direct users to the project's official Slack channel.

### Changes Made
Updated the href for the "Join Our Community" button to point to the Slack invite URL.

Ensured the link opens in a new tab with target="_blank" and rel="noopener noreferrer" for security.